### PR TITLE
Fix too many values to unpack.

### DIFF
--- a/genbmm/sparse.py
+++ b/genbmm/sparse.py
@@ -587,7 +587,7 @@ class BandedMaxMul(torch.autograd.Function):
         at = BandedMatrix(a, a_lu, a_ld, -1e9)
         bt = BandedMatrix(b, b_lu, b_ld, -1e9)
 
-        _, indices2 = _genbmm.forward_band(
+        _, indices2, _ = _genbmm.forward_band(
             bt.data.contiguous(), bt.lu, bt.ld, at.data.contiguous(), at.lu, at.ld, 1
         )
 


### PR DESCRIPTION
`forward_band` returned a longer tuple than the calling code expected. This PR ignores the extra third element in the return value.